### PR TITLE
Allow guide content pages at expansion points

### DIFF
--- a/handlers/guides/guides.go
+++ b/handlers/guides/guides.go
@@ -138,10 +138,16 @@ func buildNavigation(filename string, base string, ext string) {
 				// Step into tree
 				current = current[id].Child
 			} else {
-				current[id] = &NavigationNode{
-					Id:   id,
-					Uri:  route,
-					Name: name,
+				// If this is the leaf node for this hierarchy, we should set a route
+				if currentItem, ok := current[id]; !ok {
+					current[id] = &NavigationNode{
+						Id:   id,
+						Uri:  route,
+						Name: name,
+						Child: make(map[string]*NavigationNode),
+					}
+				} else {
+					currentItem.Uri = route
 				}
 			}
 		}


### PR DESCRIPTION
This change allows content be be displayed when you have a content structure of the form:

Introduction
    |
    |--------Detailed content 1
    |
    |--------Detailed content 2

so that when the user clicks on Introduction, they don't get a blank page

This may not be the right pattern in all cases, but its good to have as an option.